### PR TITLE
Add version to package.json

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -30,6 +30,7 @@
     "vite": "^3.0.5"
   },
   "name": "@tomic/root",
+  "version": "0.34.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This should help with some of the tools we are trying to use to package this for Summer of Nix as part of https://github.com/ngi-nix/ngipkgs/issues/15

One unclear thing is that https://github.com/atomicdata-dev/atomic-server/releases/tag/v0.34.3 is tagged in git as `0.34.3` but the title of the release is `0.34.5`. Not sure if that is a typo (the patch version is different), but we went with the git tag.