### PR TITLE
fix(docs): correct dead link to install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ https://user-images.githubusercontent.com/2183313/139728539-d69b899f-6f9b-44cb-a
 
 ## Documentation
 
-Check out the [documentation](http://docs.atomicdata.dev/atomicserver/intro.html) for installation instructions, API docs, and more.
+Check out the [documentation] for installation instructions, API docs, and more.
 
 ## Contribute
 
 Issues and PRs are welcome!
 And join our [Discord][discord-url]!
 [Read more in the Contributors guide.](CONTRIBUTE.md)
+
+[documentation]:https://docs.atomicdata.dev/atomicserver/installation
 
 [discord-badge]: https://img.shields.io/discord/723588174747533393.svg?logo=discord
 [discord-url]: https://discord.gg/a72Rv2P


### PR DESCRIPTION
~~PR Checklist:~~

~~- [ ] Link to related issues: #number~~
~~- [ ] Add changelog entry linking to issue, describe API changes~~
~~- [ ] Add tests (optional)~~
~~- [ ] (If new feature) add to description / readme~~

there's no linking api change, test or issue since this is just a dead link fix. 

## Overview

the link to install instructions from the main README is broken (see 'dead link' below). it points to `atomicserver/intro.html`. 
<details><summary>dead link</summary>

![firefox_g2laaP27uA](https://github.com/atomicdata-dev/atomic-server/assets/62955101/5fd52b37-15ca-4504-a36a-025c2a046ccf)
</details>

## Changes Summary
- I updated the url to point to the install page `atomicserver/installation`
- I opted to follow the md link style as the badges, putting the hyperlink at the footer of the doc 
<details><summary>manual test</summary>


![firefox_e2E5Y6XLCk](https://github.com/atomicdata-dev/atomic-server/assets/62955101/f914eed6-ec4d-4f33-b413-a164a0ed7956)
</details>