### PR TITLE
Give Db a destructor invoking self.db.flush()

### DIFF
--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -318,6 +318,15 @@ impl Db {
     }
 }
 
+impl Drop for Db {
+    fn drop(&mut self) {
+        match self.db.flush() {
+            Ok(..) => (),
+            Err(e) => eprintln!("Failed to flush the database: {}", e),
+        };
+    }
+}
+
 impl Storelike for Db {
     #[instrument(skip(self))]
     fn add_atoms(&self, atoms: Vec<Atom>) -> AtomicResult<()> {


### PR DESCRIPTION
Without this, any data we have added is only going to be properly persisted if sled happened to complete one of its automatic syncs after the addition (this happens every 500ms by default, [per their README](https://github.com/spacejam/sled?tab=readme-ov-file#expectations-gotchas-advice)).

When running a server, this is usually not an issue, but a command like `atomic-server import` may complete quite quickly, making us lose some or even all of our data to be imported. (In fact, this is how I found the issue: I was wondering why the import command seemed to have no effect.)
