### PR TITLE
 #914 Fix changing subject in new form could cause parent change in e…

### DIFF
--- a/browser/CHANGELOG.md
+++ b/browser/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog covers all five packages, as they are (for now) updated as a whol
 - Moved the resource context menu to the top of the page.
 - [#861](https://github.com/atomicdata-dev/atomic-server/issues/861) Fix long usernames overflowing on the share page.
 - [#906](https://github.com/atomicdata-dev/atomic-server/issues/906) Reset changes after clicking the cancel button in a form or navigating away.
+- [#914](https://github.com/atomicdata-dev/atomic-server/issues/914) Fix an issue where changing the subject in a new resource form could update the parent of existing resources if their subject matched the new subject.
 
 ### @tomic/lib
 

--- a/browser/data-browser/src/components/forms/NewForm/useNewForm.ts
+++ b/browser/data-browser/src/components/forms/NewForm/useNewForm.ts
@@ -41,6 +41,11 @@ export const useNewForm = (args: UseNewForm) => {
   // When the resource is created or updated, make sure that the parent and class are present
   useEffect(() => {
     (async () => {
+      if (!resource.new) {
+        // The resource we are trying to create already exists, don't update any values.
+        return;
+      }
+
       if (parentVal !== parent) {
         await resource.set(core.properties.parent, parent);
       }


### PR DESCRIPTION
Fix an issue where changing the subject in a new resource form could update the parent of existing resources if their subject matched the new subject.

## Related Issues

closes #914

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [ ] Add or update tests if needed
- [ ] Update docs if needed
