### PR TITLE
Move `commit::apply_opts` to `store::apply_commit` #297

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ By far most changes relate to `atomic-server`, so if not specified, assume the c
 **Changes to JS assets (including the front-end and JS libraries) are not shown here**, but in [`/browser/CHANGELOG`](/browser/CHANGELOG.md).
 See [STATUS.md](server/STATUS.md) to learn more about which features will remain stable.
 
+## [UNRELEASED]
+
+- Speed up Commits by bundling DB transactions #297
+- Introduce `Db::apply_transaction` and `Storelike::apply_commit`
+- Deprecate `add_atom_to_index` and `remove_atom_from_index` as public methods.
+
 ## [v0.39.0] - 2024-08-21
 
 - The download endpoint can now optimize images on the fly. This is controlled via query parameters. #257

--- a/lib/benches/benchmarks.rs
+++ b/lib/benches/benchmarks.rs
@@ -23,14 +23,6 @@ fn random_resource(atom: &Atom) -> Resource {
 fn criterion_benchmark(c: &mut Criterion) {
     let store = Db::init_temp("bench").unwrap();
 
-    c.bench_function("add_atom_to_index", |b| {
-        b.iter(|| {
-            let atom = random_atom();
-            let resource = random_resource(&random_atom());
-            store.add_atom_to_index(&atom, &resource).unwrap();
-        })
-    });
-
     c.bench_function("add_resource", |b| {
         b.iter(|| {
             let resource = random_resource(&random_atom());

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -17,7 +17,7 @@ use std::{
 use tracing::{info, instrument};
 
 use crate::{
-    agents::{decode_base64, ForAgent},
+    agents::ForAgent,
     atoms::IndexAtom,
     commit::{CommitOpts, CommitResponse},
     db::{
@@ -26,12 +26,11 @@ use crate::{
     },
     endpoints::{default_endpoints, Endpoint, HandleGetContext},
     errors::{AtomicError, AtomicResult},
-    hierarchy,
     resources::PropVals,
     storelike::{Query, QueryResult, Storelike},
     urls,
     values::SortableValue,
-    Atom, Commit, Resource, Value,
+    Atom, Commit, Resource,
 };
 
 use self::{
@@ -441,179 +440,72 @@ impl Storelike for Db {
         self.set_propvals(resource.get_subject(), resource.get_propvals())
     }
 
-    /// Apply a single signed Commit to the store.
+    /// Apply a single signed Commit to the Db.
     /// Creates, edits or destroys a resource.
     /// Allows for control over which validations should be performed.
     /// Returns the generated Commit, the old Resource and the new Resource.
     #[tracing::instrument(skip(self))]
-    fn apply_commit(&self, commit: &Commit, opts: &CommitOpts) -> AtomicResult<CommitResponse> {
+    fn apply_commit(&self, commit: Commit, opts: &CommitOpts) -> AtomicResult<CommitResponse> {
         let store = self;
-        let subject_url = url::Url::parse(&commit.subject)
-            .map_err(|e| format!("Subject '{}' is not a URL. {}", commit.subject, e))?;
 
-        if subject_url.query().is_some() {
-            return Err("Subject URL cannot have query parameters".into());
-        }
-
-        if opts.validate_signature {
-            let signature = match commit.signature.as_ref() {
-                Some(sig) => sig,
-                None => return Err("No signature set".into()),
-            };
-            let pubkey_b64 = store
-                .get_resource(&commit.signer)?
-                .get(urls::PUBLIC_KEY)?
-                .to_string();
-            let agent_pubkey = decode_base64(&pubkey_b64)?;
-            let stringified_commit = commit.serialize_deterministically_json_ad(self)?;
-            let peer_public_key =
-                ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, agent_pubkey);
-            let signature_bytes = decode_base64(signature)?;
-            peer_public_key
-                .verify(stringified_commit.as_bytes(), &signature_bytes)
-                .map_err(|_e| {
-                    format!(
-                        "Incorrect signature for Commit. This could be due to an error during signing or serialization of the commit. Compare this to the serialized commit in the client: {}",
-                        stringified_commit,
-                    )
-                })?;
-        }
-        // Check if the created_at lies in the past
-        if opts.validate_timestamp {
-            commit.check_timestamp()?;
-        }
-
-        commit.check_for_circular_parents()?;
-
-        let commit_resource: Resource = commit.into_resource(store)?;
-        let mut is_new = false;
-        // Create a new resource if it doens't exist yet
-        let mut resource_old = match store.get_resource(&commit.subject) {
-            Ok(rs) => rs,
-            Err(_) => {
-                is_new = true;
-                Resource::new(commit.subject.clone())
-            }
-        };
-
-        // Make sure the one creating the commit had the same idea of what the current state is.
-        if !is_new && opts.validate_previous_commit {
-            if let Ok(last_commit_val) = resource_old.get(urls::LAST_COMMIT) {
-                let last_commit = last_commit_val.to_string();
-
-                if let Some(prev_commit) = commit.previous_commit.clone() {
-                    // TODO: try auto merge
-                    if last_commit != prev_commit {
-                        return Err(format!(
-                            "previousCommit mismatch. Had lastCommit '{}' in Resource {}, but got in Commit '{}'. Perhaps you created the Commit based on an outdated version of the Resource.",
-                            last_commit, subject_url, prev_commit,
-                        )
-                        .into());
-                    }
-                } else {
-                    return Err(format!("Missing `previousCommit`. Resource {} already exists, and it has a `lastCommit` field, so a `previousCommit` field is required in your Commit.", commit.subject).into());
-                }
-            } else {
-                // If there is no lastCommit in the Resource, we'll accept the Commit.
-                tracing::warn!("No `lastCommit` in Resource. This can be a bug, or it could be that the resource was never properly updated.");
-            }
-        };
-
-        let applied = commit
-            .apply_changes(resource_old.clone(), store, false)
-            .map_err(|e| {
-                format!(
-                    "Error applying changes to Resource {}. {}",
-                    commit.subject, e
-                )
-            })?;
-        let mut resource_new = applied.resource;
-
-        if opts.validate_rights {
-            let validate_for = opts.validate_for_agent.as_ref().unwrap_or(&commit.signer);
-            if is_new {
-                hierarchy::check_append(store, &resource_new, &validate_for.into())?;
-            } else {
-                // Set a parent only if the rights checks are to be validated.
-                // If there is no explicit parent set on the previous resource, use a default.
-                // Unless it's a Drive!
-                if resource_old.get(urls::PARENT).is_err() {
-                    let default_parent = store.get_self_url().ok_or("There is no self_url set, and no parent in the Commit. The commit can not be applied.")?;
-                    resource_old.set(
-                        urls::PARENT.into(),
-                        Value::AtomicUrl(default_parent),
-                        store,
-                    )?;
-                }
-                // This should use the _old_ resource, no the new one, as the new one might maliciously give itself write rights.
-                hierarchy::check_write(store, &resource_old, &validate_for.into())?;
-            }
-        };
-        // Check if all required props are there
-        if opts.validate_schema {
-            resource_new.check_required_props(store)?;
-        }
-
-        // Set the `lastCommit` to the newly created Commit
-        resource_new.set(
-            urls::LAST_COMMIT.to_string(),
-            Value::AtomicUrl(commit_resource.get_subject().into()),
-            store,
-        )?;
-
-        let _resource_new_classes = resource_new.get_classes(store)?;
+        let commit_response = commit.validate_and_apply(opts, store)?;
 
         // BEFORE APPLY COMMIT HANDLERS
-        #[cfg(feature = "db")]
-        for class in &_resource_new_classes {
-            match class.subject.as_str() {
-                urls::COMMIT => return Err("Commits can not be edited or created directly.".into()),
-                urls::INVITE => {
-                    crate::plugins::invite::before_apply_commit(store, commit, &resource_new)?
-                }
-                _other => {}
-            };
-        }
-
-        // If a Destroy field is found, remove the resource and return early
-        // TODO: Should we remove the existing commits too? Probably.
-        if let Some(destroy) = commit.destroy {
-            if destroy {
-                // Note: the value index is updated before this action, in resource.apply_changes()
-                store.remove_resource(&commit.subject)?;
-                store.add_resource_opts(&commit_resource, false, opts.update_index, false)?;
-                return Ok(CommitResponse {
-                    resource_new: None,
-                    resource_old: Some(resource_old),
-                    commit_resource,
-                    commit_struct: commit.clone(),
-                });
+        // TODO: Move to something dynamic
+        if let Some(resource_new) = &commit_response.resource_new {
+            let _resource_new_classes = resource_new.get_classes(store)?;
+            #[cfg(feature = "db")]
+            for class in &_resource_new_classes {
+                match class.subject.as_str() {
+                    urls::COMMIT => {
+                        return Err("Commits can not be edited or created directly.".into())
+                    }
+                    urls::INVITE => crate::plugins::invite::before_apply_commit(
+                        store,
+                        &commit_response.commit,
+                        &resource_new,
+                    )?,
+                    _other => {}
+                };
             }
         }
-
         // Save the Commit to the Store. We can skip the required props checking, but we need to make sure the commit hasn't been applied before.
-        store.add_resource_opts(&commit_resource, false, opts.update_index, false)?;
-        // Save the resource, but skip updating the index - that has been done in a previous step.
-        store.add_resource_opts(&resource_new, false, false, true)?;
+        store.add_resource_opts(
+            &commit_response.commit_resource,
+            false,
+            opts.update_index,
+            false,
+        )?;
 
-        if opts.update_index {
-            for atom in applied.remove_atoms {
-                store
-                    .remove_atom_from_index(&atom, &resource_old)
-                    .map_err(|e| format!("Error removing atom from index: {e}  Atom: {e}"))?
-            }
-            for atom in applied.add_atoms {
-                store
-                    .add_atom_to_index(&atom, &resource_new)
-                    .map_err(|e| format!("Error adding atom to index: {e}  Atom: {e}"))?;
-            }
-        }
+        match (&commit_response.resource_old, &commit_response.resource_new) {
+            (None, None) => {
+                return Err("Neither an old nor a new resource is returned from the commit - something went wrong.".into())
+            },
+            (None, Some(new)) => {
+                self.add_resource(new)?;
+            },
+            (Some(_old), Some(new)) => {
+                self.add_resource(new)?;
 
-        let commit_response = CommitResponse {
-            resource_new: Some(resource_new.clone()),
-            resource_old: Some(resource_old),
-            commit_resource,
-            commit_struct: commit.clone(),
+                if opts.update_index {
+                    for atom in &commit_response.remove_atoms {
+                        store
+                            .remove_atom_from_index(&atom, &_old)
+                            .map_err(|e| format!("Error removing atom from index: {e}  Atom: {e}"))?
+                    }
+                    for atom in &commit_response.add_atoms {
+                        store
+                            .add_atom_to_index(&atom, &new)
+                            .map_err(|e| format!("Error adding atom to index: {e}  Atom: {e}"))?;
+                    }
+                }
+            },
+            (Some(_old), None) => {
+                assert_eq!(_old.get_subject(), &commit_response.commit.subject);
+                assert!(&commit_response.commit.destroy.expect("Resource was removed but `commit.destroy` was not set!"));
+                self.remove_resource(&commit_response.commit.subject)?;
+                return Ok(commit_response)
+            }
         };
 
         store.handle_commit(&commit_response);
@@ -622,17 +514,20 @@ impl Storelike for Db {
         // Commit has been checked and saved.
         // Here you can add side-effects, such as creating new Commits.
         #[cfg(feature = "db")]
-        for class in _resource_new_classes {
-            match class.subject.as_str() {
-                urls::MESSAGE => crate::plugins::chatroom::after_apply_commit_message(
-                    store,
-                    commit,
-                    &resource_new,
-                )?,
-                _other => {}
-            };
+        if let Some(resource_new) = &commit_response.resource_new {
+            let _resource_new_classes = resource_new.get_classes(store)?;
+            #[cfg(feature = "db")]
+            for class in &_resource_new_classes {
+                match class.subject.as_str() {
+                    urls::MESSAGE => crate::plugins::chatroom::after_apply_commit_message(
+                        store,
+                        &commit_response.commit,
+                        &resource_new,
+                    )?,
+                    _other => {}
+                };
+            }
         }
-
         Ok(commit_response)
     }
 

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -12,7 +12,7 @@ Therefore, we need migrations to convert the old schema to the new one.
 - Update the Tree key used in [Db::init]
  */
 
-use crate::{errors::AtomicResult, Db, Storelike};
+use crate::{errors::AtomicResult, Db};
 
 /// Checks the current version(s) of the internal Store, and performs migrations if needed.
 pub fn migrate_maybe(store: &Db) -> AtomicResult<()> {

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -9,7 +9,7 @@ Therefore, we need migrations to convert the old schema to the new one.
 - Write a function called `v{OLD}_to_v{NEW} that takes a [Db]. Make sure it removed the old `Tree`. Use [assert] to check if the process worked.
 - In [migrate_maybe] add the key of the outdated Tree
 - Add the function to the [migrate_maybe] `match` statement, select the older version of the Tree
-- Update the Tree key used in [Db::init]
+- Update the Tree key used in [crate::db::trees]
  */
 
 use crate::{errors::AtomicResult, Db};

--- a/lib/src/db/test.rs
+++ b/lib/src/db/test.rs
@@ -155,7 +155,15 @@ fn destroy_resource_and_check_collection_and_commits() {
         "The commits collection did not increase after saving the resource."
     );
 
-    _res.resource_new.unwrap().destroy(&store).unwrap();
+    let clone = _res.resource_new.clone().unwrap();
+    let resp = _res.resource_new.unwrap().destroy(&store).unwrap();
+    assert!(resp.resource_new.is_none());
+    assert_eq!(
+        resp.resource_old.as_ref().unwrap().to_json_ad().unwrap(),
+        clone.to_json_ad().unwrap(),
+        "JSON AD differs between removed resource and resource passed back from commit"
+    );
+    assert!(resp.resource_old.is_some());
     let agents_collection_3 = store
         .get_resource_extended(&agents_url, false, for_agent)
         .unwrap();

--- a/lib/src/db/trees.rs
+++ b/lib/src/db/trees.rs
@@ -1,0 +1,87 @@
+use crate::atoms::IndexAtom;
+
+use super::{prop_val_sub_index::propvalsub_key, val_prop_sub_index::valpropsub_key};
+
+#[derive(Debug)]
+pub enum Tree {
+    /// Full resources, Key: Subject, Value: [Resource](crate::Resource)
+    Resources,
+    /// Stores the members of Collections, easily sortable.
+    QueryMembers,
+    /// A list of all the Collections currently being used. Is used to update `query_index`.
+    WatchedQueries,
+    /// Index sorted by {Property}-{Value}-{Subject}.
+    /// Used for queries where the property is known.
+    PropValSub,
+    /// Reference index, used for queries where the value (or one of the values, in case of an array) is but the subject is not.
+    /// Index sorted by {Value}-{Property}-{Subject}.
+    ValPropSub,
+}
+
+const RESOURCES: &str = "resources_v1";
+const VALPROPSUB: &str = "reference_index_v1";
+const QUERY_MEMBERS: &str = "members_index";
+const PROPVALSUB: &str = "prop_val_sub_index";
+const QUERIES_WATCHED: &str = "watched_queries";
+
+impl std::fmt::Display for Tree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Tree::Resources => f.write_str(RESOURCES),
+            Tree::WatchedQueries => f.write_str(QUERIES_WATCHED),
+            Tree::PropValSub => f.write_str(PROPVALSUB),
+            Tree::ValPropSub => f.write_str(VALPROPSUB),
+            Tree::QueryMembers => f.write_str(QUERY_MEMBERS),
+        }
+    }
+}
+
+// convert Tree into AsRef<[u8]> by using the string above
+impl AsRef<[u8]> for Tree {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Tree::Resources => RESOURCES.as_bytes(),
+            Tree::WatchedQueries => QUERIES_WATCHED.as_bytes(),
+            Tree::PropValSub => PROPVALSUB.as_bytes(),
+            Tree::ValPropSub => VALPROPSUB.as_bytes(),
+            Tree::QueryMembers => QUERY_MEMBERS.as_bytes(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Method {
+    Insert,
+    Delete,
+}
+
+/// A single operation to be executed on the database.
+#[derive(Debug)]
+pub struct Operation {
+    pub tree: Tree,
+    pub method: Method,
+    pub key: Vec<u8>,
+    pub val: Option<Vec<u8>>,
+}
+
+impl Operation {
+    pub fn remove_atom_from_reference_index(index_atom: &IndexAtom) -> Self {
+        Operation {
+            tree: Tree::ValPropSub,
+            method: Method::Delete,
+            key: valpropsub_key(index_atom),
+            val: None,
+        }
+    }
+    pub fn remove_atom_from_prop_val_sub_index(index_atom: &IndexAtom) -> Self {
+        Operation {
+            tree: Tree::PropValSub,
+            method: Method::Delete,
+            key: propvalsub_key(index_atom),
+            val: None,
+        }
+    }
+}
+
+/// A set of [Operation]s that should be executed atomically by the database.
+pub type Transaction = Vec<Operation>;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -344,7 +344,7 @@ fn parse_json_ad_map_to_resource(
                 };
 
                 store
-                    .apply_commit(&commit, &opts)
+                    .apply_commit(commit, &opts)
                     .map_err(|e| format!("Failed to save {}: {}", r.get_subject(), e))?
                     .resource_new
                     .unwrap()

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -351,8 +351,8 @@ fn parse_json_ad_map_to_resource(
                     update_index: true,
                 };
 
-                commit
-                    .apply_opts(store, &opts)
+                store
+                    .apply_commit(&commit, &opts)
                     .map_err(|e| format!("Failed to save {}: {}", r.get_subject(), e))?
                     .resource_new
                     .unwrap()

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -127,15 +127,7 @@ pub fn parse_json_ad_string(
         ),
         _other => return Err("Root JSON element must be an object or array.".into()),
     }
-    // For most save menthods, we need to add the atoms to the index here.
-    // The `Commit` feature adds to index by itself, so we can skip that step here.
-    if parse_opts.save != SaveOpts::Commit {
-        for res in &vec {
-            for atom in res.to_atoms() {
-                store.add_atom_to_index(&atom, res)?;
-            }
-        }
-    }
+
     Ok(vec)
 }
 

--- a/lib/src/plugins/chatroom.rs
+++ b/lib/src/plugins/chatroom.rs
@@ -101,7 +101,8 @@ pub fn after_apply_commit_message(
         let new_message = crate::values::SubResource::Resource(Box::new(resource_new.to_owned()));
         commit_builder.push_propval(urls::MESSAGES, new_message)?;
         let commit = commit_builder.sign(&store.get_default_agent()?, store, &chat_room)?;
-        let resp = commit.validate_and_apply(&CommitOpts::no_validations_no_index(), store)?;
+        let resp =
+            commit.validate_and_build_response(&CommitOpts::no_validations_no_index(), store)?;
 
         store.handle_commit(&resp);
     }

--- a/lib/src/plugins/chatroom.rs
+++ b/lib/src/plugins/chatroom.rs
@@ -6,7 +6,7 @@ They list a bunch of Messages.
 
 use crate::{
     agents::ForAgent,
-    commit::{CommitBuilder, CommitResponse},
+    commit::{CommitBuilder, CommitOpts},
     errors::AtomicResult,
     storelike::Query,
     urls::{self, PARENT},
@@ -101,15 +101,9 @@ pub fn after_apply_commit_message(
         let new_message = crate::values::SubResource::Resource(Box::new(resource_new.to_owned()));
         commit_builder.push_propval(urls::MESSAGES, new_message)?;
         let commit = commit_builder.sign(&store.get_default_agent()?, store, &chat_room)?;
+        let resp = commit.validate_and_apply(&CommitOpts::no_validations_no_index(), store)?;
 
-        let commit_response = CommitResponse {
-            commit_resource: commit.into_resource(store)?,
-            resource_new: None,
-            resource_old: None,
-            commit_struct: commit,
-        };
-
-        store.handle_commit(&commit_response);
+        store.handle_commit(&resp);
     }
     Ok(())
 }

--- a/lib/src/plugins/versioning.rs
+++ b/lib/src/plugins/versioning.rs
@@ -135,8 +135,8 @@ pub fn construct_version(
     let mut version = Resource::new(subject.into());
     for commit in commits {
         if let Some(current_commit) = commit.url.clone() {
-            let updated = commit.apply_changes(version, store, false)?;
-            version = updated;
+            let applied = commit.apply_changes(version, store, false)?;
+            version = applied.resource;
             // Stop iterating when the target commit has been applied.
             if current_commit == commit_url {
                 break;

--- a/lib/src/plugins/versioning.rs
+++ b/lib/src/plugins/versioning.rs
@@ -136,7 +136,7 @@ pub fn construct_version(
     for commit in commits {
         if let Some(current_commit) = commit.url.clone() {
             let applied = commit.apply_changes(version, store, false)?;
-            version = applied.resource;
+            version = applied.resource_new;
             // Stop iterating when the target commit has been applied.
             if current_commit == commit_url {
                 break;

--- a/lib/src/plugins/versioning.rs
+++ b/lib/src/plugins/versioning.rs
@@ -95,6 +95,7 @@ fn get_commits_for_resource(subject: &str, store: &impl Storelike) -> AtomicResu
     let mut q = Query::new_prop_val(urls::SUBJECT, subject);
     q.sort_by = Some(urls::CREATED_AT.into());
     let result = store.query(&q)?;
+
     let filtered: Vec<Commit> = result
         .resources
         .iter()
@@ -135,7 +136,7 @@ pub fn construct_version(
     let mut version = Resource::new(subject.into());
     for commit in commits {
         if let Some(current_commit) = commit.url.clone() {
-            let applied = commit.apply_changes(version, store, false)?;
+            let applied = commit.apply_changes(version, store)?;
             version = applied.resource_new;
             // Stop iterating when the target commit has been applied.
             if current_commit == commit_url {
@@ -199,7 +200,8 @@ mod test {
         resource
             .set_string(crate::urls::DESCRIPTION.into(), second_val, &store)
             .unwrap();
-        let second_commit = resource.save_locally(&store).unwrap().commit_resource;
+        let commit_resp = resource.save_locally(&store).unwrap();
+        let second_commit = commit_resp.commit_resource;
         let commits = get_commits_for_resource(subject, &store).unwrap();
         assert_eq!(commits.len(), 2, "We should have two commits");
 

--- a/lib/src/resources.rs
+++ b/lib/src/resources.rs
@@ -366,7 +366,7 @@ impl Resource {
             validate_previous_commit: false,
             update_index: true,
         };
-        let commit_response = commit.apply_opts(store, &opts)?;
+        let commit_response = store.apply_commit(&commit, &opts)?;
         if let Some(new) = &commit_response.resource_new {
             self.subject = new.subject.clone();
             self.propvals = new.propvals.clone();
@@ -394,7 +394,7 @@ impl Resource {
             validate_previous_commit: false,
             update_index: true,
         };
-        let commit_response = commit.apply_opts(store, &opts)?;
+        let commit_response = store.apply_commit(&commit, &opts)?;
         if let Some(new) = &commit_response.resource_new {
             self.subject = new.subject.clone();
             self.propvals = new.propvals.clone();
@@ -694,9 +694,9 @@ mod test {
             .clone()
             .sign(&agent, &store, &new_resource)
             .unwrap();
-        commit
-            .apply_opts(
-                &store,
+        store
+            .apply_commit(
+                &commit,
                 &CommitOpts {
                     validate_schema: true,
                     validate_signature: true,

--- a/lib/src/resources.rs
+++ b/lib/src/resources.rs
@@ -366,7 +366,7 @@ impl Resource {
             validate_previous_commit: false,
             update_index: true,
         };
-        let commit_response = store.apply_commit(&commit, &opts)?;
+        let commit_response = store.apply_commit(commit, &opts)?;
         if let Some(new) = &commit_response.resource_new {
             self.subject = new.subject.clone();
             self.propvals = new.propvals.clone();
@@ -394,7 +394,7 @@ impl Resource {
             validate_previous_commit: false,
             update_index: true,
         };
-        let commit_response = store.apply_commit(&commit, &opts)?;
+        let commit_response = store.apply_commit(commit, &opts)?;
         if let Some(new) = &commit_response.resource_new {
             self.subject = new.subject.clone();
             self.propvals = new.propvals.clone();
@@ -696,7 +696,7 @@ mod test {
             .unwrap();
         store
             .apply_commit(
-                &commit,
+                commit,
                 &CommitOpts {
                     validate_schema: true,
                     validate_signature: true,
@@ -792,7 +792,7 @@ mod test {
             "The first element should be the appended value"
         );
         let resp = resource.save_locally(&store).unwrap();
-        assert!(resp.commit_struct.push.is_some());
+        assert!(resp.commit_resource.get(urls::PUSH).is_ok());
 
         let new_val = resp
             .resource_new

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -158,14 +158,6 @@ impl Storelike for Store {
         Box::new(self.hashmap.lock().unwrap().clone().into_values())
     }
 
-    fn apply_commit(
-        &self,
-        commit: &crate::Commit,
-        opts: &crate::commit::CommitOpts,
-    ) -> AtomicResult<crate::commit::CommitResponse> {
-        todo!()
-    }
-
     fn get_server_url(&self) -> &str {
         // TODO Should be implemented later when companion functionality is here
         // https://github.com/atomicdata-dev/atomic-server/issues/6

--- a/lib/src/store.rs
+++ b/lib/src/store.rs
@@ -158,6 +158,14 @@ impl Storelike for Store {
         Box::new(self.hashmap.lock().unwrap().clone().into_values())
     }
 
+    fn apply_commit(
+        &self,
+        commit: &crate::Commit,
+        opts: &crate::commit::CommitOpts,
+    ) -> AtomicResult<crate::commit::CommitResponse> {
+        todo!()
+    }
+
     fn get_server_url(&self) -> &str {
         // TODO Should be implemented later when companion functionality is here
         // https://github.com/atomicdata-dev/atomic-server/issues/6

--- a/lib/src/storelike.rs
+++ b/lib/src/storelike.rs
@@ -63,6 +63,15 @@ pub trait Storelike: Sized {
     /// If Include_external is false, this is filtered by selecting only resoureces that match the `self` URL of the store.
     fn all_resources(&self, include_external: bool) -> Box<dyn Iterator<Item = Resource>>;
 
+    /// Takes a Commit and applies it to the Store.
+    /// This includes changing the resource, writing the changes, verifying the checks specified in your CommitOpts
+    /// The returned CommitResponse contains the new resource and the saved Commit Resource.
+    fn apply_commit(
+        &self,
+        commit: &crate::Commit,
+        opts: &crate::commit::CommitOpts,
+    ) -> AtomicResult<CommitResponse>;
+
     /// Constructs the value index from all resources in the store. Could take a while.
     fn build_index(&self, include_external: bool) -> AtomicResult<()> {
         tracing::info!("Building index (this could take a few minutes for larger databases)");

--- a/lib/src/storelike.rs
+++ b/lib/src/storelike.rs
@@ -65,7 +65,9 @@ pub trait Storelike: Sized {
         commit: crate::Commit,
         opts: &crate::commit::CommitOpts,
     ) -> AtomicResult<CommitResponse> {
-        let applied = commit.validate_and_apply(opts, self)?;
+        let applied = commit.validate_and_build_response(opts, self)?;
+
+        self.add_resource(&applied.commit_resource)?;
 
         match (&applied.resource_old, &applied.resource_new) {
             (None, None) => {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -45,3 +45,15 @@ pub fn random_string(n: usize) -> String {
         .collect();
     random_string.to_lowercase()
 }
+
+pub fn check_timestamp_in_past(timestamp: i64, difference: i64) -> AtomicResult<()> {
+    let now = crate::utils::now();
+    if timestamp > now + difference {
+        return Err(format!(
+                "Commit CreatedAt timestamp must lie in the past. Check your clock. Timestamp now: {} CreatedAt is: {}",
+                now, timestamp
+            )
+            .into());
+    }
+    return Ok(());
+}

--- a/server/build.rs
+++ b/server/build.rs
@@ -18,6 +18,7 @@ struct Dirs {
 }
 
 fn main() -> std::io::Result<()> {
+    // return Ok(());
     const BROWSER_ROOT: &str = "../browser/";
     let dirs: Dirs = {
         Dirs {

--- a/server/build.rs
+++ b/server/build.rs
@@ -18,7 +18,8 @@ struct Dirs {
 }
 
 fn main() -> std::io::Result<()> {
-    return Ok(());
+    // Uncomment this line if you want faster builds during development
+    // return Ok(());
     const BROWSER_ROOT: &str = "../browser/";
     let dirs: Dirs = {
         Dirs {

--- a/server/build.rs
+++ b/server/build.rs
@@ -18,7 +18,7 @@ struct Dirs {
 }
 
 fn main() -> std::io::Result<()> {
-    // return Ok(());
+    return Ok(());
     const BROWSER_ROOT: &str = "../browser/";
     let dirs: Dirs = {
         Dirs {

--- a/server/src/commit_monitor.rs
+++ b/server/src/commit_monitor.rs
@@ -103,7 +103,7 @@ impl CommitMonitor {
     /// and update the value index.
     /// The search index is only updated if the last search commit is 15 seconds or older.
     fn handle_internal(&mut self, msg: CommitMessage) -> AtomicServerResult<()> {
-        let target = msg.commit_response.commit_struct.subject.clone();
+        let target = msg.commit_response.commit.subject.clone();
 
         // Notify websocket listeners
         if let Some(subscribers) = self.subscriptions.get(&target) {

--- a/server/src/handlers/commit.rs
+++ b/server/src/handlers/commit.rs
@@ -36,7 +36,7 @@ pub async fn post_commit(
         validate_for_agent: Some(incoming_commit.signer.to_string()),
         update_index: true,
     };
-    let commit_response = store.apply_commit(&incoming_commit, &opts)?;
+    let commit_response = store.apply_commit(incoming_commit, &opts)?;
 
     let message = commit_response.commit_resource.to_json_ad()?;
 

--- a/server/src/handlers/commit.rs
+++ b/server/src/handlers/commit.rs
@@ -36,7 +36,7 @@ pub async fn post_commit(
         validate_for_agent: Some(incoming_commit.signer.to_string()),
         update_index: true,
     };
-    let commit_response = incoming_commit.apply_opts(store, &opts)?;
+    let commit_response = store.apply_commit(&incoming_commit, &opts)?;
 
     let message = commit_response.commit_resource.to_json_ad()?;
 

--- a/server/src/serve.rs
+++ b/server/src/serve.rs
@@ -1,6 +1,5 @@
 use actix_cors::Cors;
 use actix_web::{middleware, web, HttpServer};
-use atomic_lib::Storelike;
 
 use crate::errors::AtomicServerResult;
 


### PR DESCRIPTION
## Related Issues

closes #297

## ToDo

- [x] Move `apply_changes` from `Commit` to `Resource::apply_commit`
- [x] Move the store specific code from `apply_opts` to `Storelike` and `Db`, where we index
- [x] Get rid of `add_atom_to_index` functions in `Storelike`
- [x] use `sled::Batch`

## Checklist
- [x] Add changelog entry linking to issue, describe API changes
- [x] Add or update tests if needed
- [ ] Update docs if needed
